### PR TITLE
Fix: Hero button now works as a normal a tag

### DIFF
--- a/components/shared/styles/2-base/_base.scss
+++ b/components/shared/styles/2-base/_base.scss
@@ -2,6 +2,11 @@
   box-sizing: border-box;
 }
 
+html {
+  scroll-behavior: smooth;
+
+}
+
 body {
   font-family: $base-font-family;
   font-size: $base-font-size;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "vonge-jekyll-bookshop-template",
       "license": "MIT",
       "devDependencies": {
         "@bookshop/browser": "^2.2.2",

--- a/site/js/common.js
+++ b/site/js/common.js
@@ -77,20 +77,6 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   /* ============================
-  // Smooth scrolling to section
-  ============================ */
-  document.querySelectorAll(".works-button").forEach(anchor => {
-    anchor.addEventListener("click", function (e) {
-      e.preventDefault();
-
-      document.querySelector(this.getAttribute("href")).scrollIntoView({
-        behavior: "smooth"
-      });
-    });
-  });
-
-
-  /* ============================
   // Testimonials Slider
   ============================ */
   if (document.querySelector(".my-slider")) {


### PR DESCRIPTION
The hero button can now link to both pages and anchor tags. Appended smooth scrolling (CSS) to the site and got rid of unnecessary JS which was previously giving buttons the smooth scroll ability 