### PR TITLE
fix `pre` block bottom-margin

### DIFF
--- a/component-library/shared/styles/2-base/_base.scss
+++ b/component-library/shared/styles/2-base/_base.scss
@@ -111,7 +111,6 @@ blockquote {
 pre {
   overflow: auto;
   padding: 15px;
-  margin-bottom: 0;
   font-size: 14px;
   white-space: pre-wrap;
   word-wrap: break-word;


### PR DESCRIPTION
Fixes #32 by simply removing the line that sets the bottom margin to 0 for `pre`. Instead of giving it another hard-coded value, it can use the defaults this way.