### PR TITLE
Bundle install can fail locally if no write permissions for gems; add…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 bookshop-live.js
 .DS_Store
 site/.bundle
+.bundle

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor
 node_modules
 bookshop-live.js
 .DS_Store
+site/.bundle

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Vonge template for CloudCannon",
   "scripts": {
     "bookshop": "bookshop-browser",
-    "jekyll:install": "BUNDLE_GEMFILE=site/Gemfile bundle install",
+    "jekyll:install": "BUNDLE_GEMFILE=site/Gemfile && bundle config set --local path 'vendor/bundle' && bundle install",
     "bookshop-dev": "bookshop-browser -p 6086 -b ./component-library",
     "bookshop-hosted": "bookshop-browser -b ./component-library -o site/js/bookshop-hosted.js",
     "bookshop-live": "bookshop-live -b ./component-library -o site/_cloudcannon/bookshop-live.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Vonge template for CloudCannon",
   "scripts": {
     "bookshop": "bookshop-browser",
-    "jekyll:install": "BUNDLE_GEMFILE=site/Gemfile && bundle config set --local path 'vendor/bundle' && bundle install",
+    "jekyll:install": "bundle config set --local path 'vendor/bundle' && BUNDLE_GEMFILE=site/Gemfile bundle install",
     "bookshop-dev": "bookshop-browser -p 6086 -b ./component-library",
     "bookshop-hosted": "bookshop-browser -b ./component-library -o site/js/bookshop-hosted.js",
     "bookshop-live": "bookshop-live -b ./component-library -o site/_cloudcannon/bookshop-live.js",


### PR DESCRIPTION
## Current issue

Reported error related to `google-protobuf` actually appears to be:

```
An error occurred while installing rake (13.2.1), and Bundler cannot continue.

In Gemfile:
  jekyll-bookshop was resolved to 3.9.0, which depends on
    jekyll was resolved to 4.3.3, which depends on
      jekyll-sass-converter was resolved to 3.1.0, which depends on
        sass-embedded was resolved to 1.86.0, which depends on
          google-protobuf was resolved to 4.30.1, which depends on
            rake
```

Which appears to be this root error:

```
Bundler::PermissionError: There was an error while trying to write to `/usr/local/__bundle/ruby/3.3.0/cache/rake-13.2.1.gem`. It is likely that you need to grant write permissions for that path.
```

From https://bundler.io/doc/troubleshooting.html

> Certain operating systems such as macOS and Ubuntu have versions of Ruby that require elevated privileges to install gems.

Solutions are to `sudo` install, or use a local configuration.

## Proposed fix

Added `bundle config set --local path 'vendor/bundle'` to the `jekyll:install`.